### PR TITLE
fix: stabilize uPlot rendering and improve chart/usage layout & styling

### DIFF
--- a/web/src/components/MemoryBars.tsx
+++ b/web/src/components/MemoryBars.tsx
@@ -58,57 +58,59 @@ const MemoryBars: FunctionalComponent<Props> = ({ sample }) => {
   ];
 
   return (
-    <section class="grid usage-grid">
-      <article
-        class="metric-card metric-card--compact"
-        title="Current GPU load averaged over the sampling interval"
-      >
-        <div class="metric-card__row">
-          <h3>GPU Load</h3>
-          <span class="metric-inline-value">{formatPercent(metrics.gpu_busy_pct, 1)}</span>
-        </div>
-        <div
-          class="progress progress--thin"
-          role="progressbar"
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={Math.round((loadRatio ?? 0) * 100)}
+    <section class="usage-section">
+      <div class="grid usage-grid">
+        <article
+          class="metric-card metric-card--compact"
+          title="Current GPU load averaged over the sampling interval"
         >
-          <span style={`width: ${(loadRatio ?? 0) * 100}%`}></span>
-        </div>
-      </article>
-      {memoryRows.map((row) => {
-        const usedText =
-          row.used != null && row.total != null
-            ? `${formatBytes(row.used)} / ${formatBytes(row.total)}`
-            : formatBytes(row.used);
-
-        return (
-          <article
-            key={row.key}
-            class="metric-card metric-card--compact"
-            title={
-              row.key === 'vram'
-                ? 'Video memory usage (bytes used out of total)'
-                : 'Graphics translation table usage (bytes used out of total)'
-            }
+          <div class="metric-card__row">
+            <h3>GPU Load</h3>
+            <span class="metric-inline-value">{formatPercent(metrics.gpu_busy_pct, 1)}</span>
+          </div>
+          <div
+            class="progress progress--thin"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round((loadRatio ?? 0) * 100)}
           >
-            <div class="metric-card__row">
-              <h3>{row.label}</h3>
-              <span class="metric-inline-value">{usedText}</span>
-            </div>
-            <div
-              class="progress progress--thin"
-              role="progressbar"
-              aria-valuemin={0}
-              aria-valuemax={100}
-              aria-valuenow={Math.round((row.ratio ?? 0) * 100)}
+            <span style={`width: ${(loadRatio ?? 0) * 100}%`}></span>
+          </div>
+        </article>
+        {memoryRows.map((row) => {
+          const usedText =
+            row.used != null && row.total != null
+              ? `${formatBytes(row.used)} / ${formatBytes(row.total)}`
+              : formatBytes(row.used);
+
+          return (
+            <article
+              key={row.key}
+              class="metric-card metric-card--compact"
+              title={
+                row.key === 'vram'
+                  ? 'Video memory usage (bytes used out of total)'
+                  : 'Graphics translation table usage (bytes used out of total)'
+              }
             >
-              <span style={`width: ${(row.ratio ?? 0) * 100}%`}></span>
-            </div>
-          </article>
-        );
-      })}
+              <div class="metric-card__row">
+                <h3>{row.label}</h3>
+                <span class="metric-inline-value">{usedText}</span>
+              </div>
+              <div
+                class="progress progress--thin"
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={Math.round((row.ratio ?? 0) * 100)}
+              >
+                <span style={`width: ${(row.ratio ?? 0) * 100}%`}></span>
+              </div>
+            </article>
+          );
+        })}
+      </div>
       {chartsEnabled && chartHistory && sampleIntervalMs ? (
         <div class="chart-section">
           <button

--- a/web/src/components/UPlotChart.tsx
+++ b/web/src/components/UPlotChart.tsx
@@ -1,3 +1,4 @@
+import uPlot from 'uplot';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 interface ChartTooltip {
@@ -23,26 +24,15 @@ const UPlotChart = ({ title, data, height = 140, stroke, valueFormatter }: Props
   const containerRef = useRef<HTMLDivElement | null>(null);
   const plotRef = useRef<any>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
-  const [uPlotModule, setUPlotModule] = useState<any>(null);
   const [tooltip, setTooltip] = useState<ChartTooltip | null>(null);
-
-  useEffect(() => {
-    let active = true;
-    void import('uplot').then((mod) => {
-      if (!active) {
-        return;
-      }
-      setUPlotModule(mod.default ?? mod);
-    });
-    return () => {
-      active = false;
-    };
-  }, []);
 
   const options = useMemo(() => {
     const plugin = {
       hooks: {
         setCursor: (u: any) => {
+          if (!u.cursor) {
+            return;
+          }
           const idx = u.cursor.idx;
           if (idx == null || idx < 0) {
             setTooltip(null);
@@ -76,15 +66,15 @@ const UPlotChart = ({ title, data, height = 140, stroke, valueFormatter }: Props
       },
       axes: [
         {
-          stroke: 'rgba(255, 255, 255, 0.5)',
+          stroke: 'rgba(241, 245, 249, 0.85)',
           grid: {
-            stroke: 'rgba(255, 255, 255, 0.06)'
+            stroke: 'rgba(255, 255, 255, 0.12)'
           }
         },
         {
-          stroke: 'rgba(255, 255, 255, 0.55)',
+          stroke: 'rgba(241, 245, 249, 0.85)',
           grid: {
-            stroke: 'rgba(255, 255, 255, 0.06)'
+            stroke: 'rgba(255, 255, 255, 0.12)'
           }
         }
       ],
@@ -93,14 +83,11 @@ const UPlotChart = ({ title, data, height = 140, stroke, valueFormatter }: Props
         {
           label: title,
           stroke,
-          width: 1.6
+          width: 2
         }
       ],
-      sync: {
-        key: 'gpu-charts',
-        setSeries: true
-      },
       cursor: {
+        show: true,
         drag: {
           x: false,
           y: false
@@ -108,6 +95,9 @@ const UPlotChart = ({ title, data, height = 140, stroke, valueFormatter }: Props
         points: {
           show: true,
           size: 5
+        },
+        sync: {
+          key: 'gpu-charts'
         }
       },
       plugins: [plugin]
@@ -115,13 +105,13 @@ const UPlotChart = ({ title, data, height = 140, stroke, valueFormatter }: Props
   }, [height, stroke, title, valueFormatter]);
 
   useEffect(() => {
-    if (!uPlotModule || !containerRef.current) {
+    if (!containerRef.current) {
       return;
     }
 
     const container = containerRef.current;
     const width = Math.max(1, container.clientWidth);
-    const uPlotCtor = uPlotModule;
+    const uPlotCtor = uPlot;
 
     if (!plotRef.current) {
       plotRef.current = new uPlotCtor({ ...options, width }, data, container);
@@ -142,7 +132,7 @@ const UPlotChart = ({ title, data, height = 140, stroke, valueFormatter }: Props
       resizeObserverRef.current?.disconnect();
       resizeObserverRef.current = null;
     };
-  }, [data, height, options, uPlotModule]);
+  }, [data, height, options]);
 
   useEffect(() => {
     return () => {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { render } from 'preact';
 import App from './App';
 import '@picocss/pico/css/pico.css';
+import 'uplot/dist/uPlot.min.css';
 import './style.css';
 
 const container = document.getElementById('root');

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -199,8 +199,13 @@ header {
   color: rgba(255, 255, 255, 0.85);
 }
 
+.usage-section {
+  display: flex;
+  flex-direction: column;
+  gap: calc(0.75rem * var(--spacing-scale));
+}
+
 .chart-section {
-  grid-column: 1 / -1;
   padding: calc(0.5rem * var(--spacing-scale));
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid rgba(255, 255, 255, 0.06);
@@ -266,10 +271,28 @@ header {
 
 .chart-canvas .uplot {
   font-family: inherit;
+  width: 100%;
 }
 
 .chart-canvas .uplot canvas {
   background: transparent;
+}
+
+.chart-canvas .uplot .u-axis text {
+  fill: rgba(241, 245, 249, 0.85);
+}
+
+.chart-canvas .uplot .u-axis .u-label {
+  fill: rgba(241, 245, 249, 0.7);
+}
+
+.chart-canvas .uplot .u-legend {
+  color: rgba(241, 245, 249, 0.8);
+}
+
+.chart-canvas .uplot .u-cursor-x,
+.chart-canvas .uplot .u-cursor-y {
+  border-color: rgba(241, 245, 249, 0.35);
 }
 
 .stats-updated {


### PR DESCRIPTION
### Motivation

- Prevent intermittent chart initialization and runtime errors caused by dynamic uPlot import and nullable cursor state. 
- Ensure the usage cards (GPU Load, VRAM, GTT) can span the full horizontal row and are not constrained by the charts grid. 
- Improve chart contrast and baseline visuals so axes, legend and cursor remain readable across browsers. 

### Description

- Replace the dynamic `import('uplot')` flow with a static `import uPlot from 'uplot'` and remove the related module state to ensure a consistent chart constructor in `web/src/components/UPlotChart.tsx`. 
- Harden cursor handling in the chart plugin by guarding `u.cursor` access inside the `setCursor` hook and prevent null/invalid index lookups. 
- Tweak chart defaults for better contrast by adjusting axis and grid stroke colors, increasing series stroke width, and configuring chart sync under `cursor.sync` in `web/src/components/UPlotChart.tsx`. 
- Move charts out of the usage grid and wrap usage cards in a new `.usage-section` so usage cards can span the full row, and update `MemoryBars.tsx` layout accordingly. 
- Import the `uPlot` stylesheet and add CSS overrides in `web/src/style.css` to force full-width charts and improve axis/legend/cursor contrast and visuals. 

### Testing

- Ran `npm install` in the `web` workspace which completed successfully with audit warnings reported. 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`; the initial pre-transform syntax error was detected and fixed, after which Vite reported "ready" (dev server started). 
- Attempted automated screenshot capture via Playwright as part of validation, but the headless Chromium process crashed during one attempt and a prior script invocation used incorrect syntax, so the screenshot step failed. 
- No unit or CI tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69704faa3e308323be4c2073d5194276)